### PR TITLE
Misc packaging fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,8 +10,8 @@ include tsconfig.json
 include package.json
 include webpack.config.js
 
-recursive-include ipycytoscape/nbextension/*
-recursive-include ipycytoscape/labextension/*
+graft ipycytoscape/nbextension
+graft ipycytoscape/labextension
 
 # Documentation
 graft docs

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ from jupyter_packaging import (
     install_npm,
     ensure_targets,
     combine_commands,
-    ensure_python,
     get_version,
 )
 
@@ -27,9 +26,6 @@ from setuptools import setup, find_packages
 name = "ipycytoscape"
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-
-# Ensure a valid python version
-ensure_python(">=3.4")
 
 # Get our version
 version = get_version(path.join(name, "_version.py"))


### PR DESCRIPTION
- Fix syntax of `MANIFEST.in` file
- Remove `ensure_python`
   - Deprecated and breaks for python 3.10 which is breaking conda-forge build (https://github.com/conda-forge/ipycytoscape-feedstock/pull/20)