### PR TITLE
Remove description-file field from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,4 @@
 universal=1
 
 [metadata]
-description-file = README.md 
 license_file = LICENSE


### PR DESCRIPTION
While installing from source I noticed that this deprecation warning was triggered.

```
C:\Users\Jens\miniconda3\envs\ipycytoscapedev\lib\site-packages\setuptools\dist.py:717: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
```

The use of description-file/description_file has no effect when using setuptools 
https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#compatibility-with-other-tools for supported 
In the form of `description-file` it triggers a deprecation warning while the other form will just be ignored.
The readme is already included via long_description in setup.py so I would suggest removing this line