### PR TITLE
rework classes in from scratch examples match other examples

### DIFF
--- a/examples/Ipycytoscape from Scratch.ipynb
+++ b/examples/Ipycytoscape from Scratch.ipynb
@@ -118,7 +118,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "225f5c36867f428fa50cb68b0e3adc73",
+       "model_id": "5ad9f090231d40ec9eaf9a07a23bbe75",
        "version_major": 2,
        "version_minor": 0
       },
@@ -165,7 +165,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6a25a502905e469292bb6ddb3ebea42d",
+       "model_id": "aa751e6fc87d4754a1896e7d8387016a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -191,7 +191,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46b0cdde507c45478f06534029fbf16e",
+       "model_id": "ae38046c18dd44c494f2e6c2a1c1fb50",
        "version_major": 2,
        "version_minor": 0
       },
@@ -229,7 +229,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "45a2ea1e8bf24eeebbd0ce143ed7eac5",
+       "model_id": "d0965d888a3545b5935c341544f7fd56",
        "version_major": 2,
        "version_minor": 0
       },
@@ -305,7 +305,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f695e71ce669495987161263bc9ddc3b",
+       "model_id": "9fabbdeba2ff4f4f8d9b6aaa54cb603d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -340,7 +340,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9347b74cb2744708b8c21973cf44fdb7",
+       "model_id": "2055e2f28a7f4b65b1b38ea05c78d148",
        "version_major": 2,
        "version_minor": 0
       },
@@ -367,7 +367,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3014eea4685946deb270fa390b08cd44",
+       "model_id": "2aecff536501486bb54f7c0a66df64d9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -410,7 +410,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e8826e2367ef453c96b221085e8c16ff",
+       "model_id": "d647ac9019cc41c7842796a70065a316",
        "version_major": 2,
        "version_minor": 0
       },
@@ -480,7 +480,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da865fcdcb6a4971b7eab93c50abf00f",
+       "model_id": "da2bff73b8284c94bc510c469a00ea7f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -573,7 +573,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb281da7cfdb4bb294d5d5255abb1bac",
+       "model_id": "df8cb964a6fd49a4948c3f6096c5c3ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -588,11 +588,11 @@
    "source": [
     "railnet= '''{\n",
     "    \"nodes\": [\n",
-    "        {\"data\": { \"id\": \"BER\", \"label\":\"HBf BER\", \"classes\":\"east\"}},\n",
-    "        {\"data\": { \"id\": \"MUN\", \"label\":\"HBf MUN\", \"classes\":\"west\"}},\n",
-    "        {\"data\": { \"id\": \"FRA\", \"label\":\"HBf FRA\", \"classes\":\"west\"}},\n",
-    "        {\"data\": { \"id\": \"HAM\", \"label\":\"HBf HAM\", \"classes\":\"west\"}},\n",
-    "        {\"data\": { \"id\": \"LEP\", \"label\":\"HBf LEP\", \"classes\":\"east\"}}\n",
+    "        {\"data\": { \"id\": \"BER\", \"label\":\"HBf BER\"}, \"classes\":\"east\"},\n",
+    "        {\"data\": { \"id\": \"MUN\", \"label\":\"HBf MUN\"}, \"classes\":\"west\"},\n",
+    "        {\"data\": { \"id\": \"FRA\", \"label\":\"HBf FRA\"}, \"classes\":\"west\"},\n",
+    "        {\"data\": { \"id\": \"HAM\", \"label\":\"HBf HAM\"}, \"classes\":\"west\"},\n",
+    "        {\"data\": { \"id\": \"LEP\", \"label\":\"HBf LEP\"}, \"classes\":\"east\"}\n",
     "        ],\n",
     "    \"edges\": [\n",
     "        {\"data\": { \"id\": \"line1\", \"source\": \"BER\", \"target\": \"MUN\",\"label\":\"200km/h\"}},\n",
@@ -610,10 +610,10 @@
     "        'font-size': '10px',\n",
     "        'label': 'data(label)',}},\n",
     "    \n",
-    "    {'selector': 'node[classes=\"east\"]','style': {\n",
+    "    {'selector': 'node.east','style': {\n",
     "        'background-color': 'yellow'}},\n",
     "    \n",
-    "     {'selector': 'node[classes=\"west\"]','style': {\n",
+    "     {'selector': 'node.west','style': {\n",
     "        'background-color': 'blue'}},\n",
     "    \n",
     "    \n",
@@ -662,7 +662,7 @@
    "source": [
     "What happended?   \n",
     "With    \n",
-    "{'selector': 'node[classes=\"east\"]',   \n",
+    "{'selector': 'node.east]',   \n",
     "'style': {'background-color': 'yellow'}},   \n",
     "\n",
     "We painted all east German cities yellow. BER as well, but BER color is overwritten by the green color of the BER node."
@@ -680,16 +680,11 @@
     "\n",
     "stay tuned."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -703,7 +698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The from scratch example uses classes embedded in the data dict rather that as a top level attribute. I found that a bit confusing since Node.classes ends up being empty (and the classes has to be found within the data dict) Here I suggest reworking this and the matching style to use classes as a top level key/value pair.

Chaning the classes value within the data dict does not seem to trigger an update to the graph but I guess that is a separate issue.