### PR TITLE
fix incorrect syntax in pytest ini file

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-py.test --ignore=examples/Neo4j_Example.ipynb
 testpaths = ipycytoscape/tests examples
 norecursedirs = node_modules .ipynb_checkpoints
-addopts = --nbval --current-env
+addopts = --nbval --current-env --ignore=examples/Neo4j_Example.ipynb


### PR DESCRIPTION
This triggers a warning in the test runner. It looks like the intention was to skip this notebook which this config does