### PR TITLE
Use pytest fixtures in edge tests

### DIFF
--- a/ipycytoscape/tests/test_graph_methods.py
+++ b/ipycytoscape/tests/test_graph_methods.py
@@ -29,6 +29,23 @@ def compare_edges(expected_edges, actual_edges):
         assert expected.classes == actual.classes
 
 
+@pytest.fixture(name="edges", scope="module")
+def _make_edges():
+    ids = ["0", "1", "2"]
+    edges = [
+        Edge(data={"source": source, "target": target})
+        for source, target in zip(ids[:-1], ids[1:])
+    ]
+    edges_weighted = [
+        Edge(data={"source": "0", "target": "1", "weight": str(i)}) for i in range(1, 3)
+    ]
+    edge_inv = Edge(data={"source": "1", "target": "0"})
+
+    edges += edges_weighted
+    edges += [edge_inv]
+    return edges
+
+
 class TestGraphRemoveMethods:
     def test_remove_edge(self):
         """
@@ -246,23 +263,10 @@ class TestGraphAddMethods:
         compare_edges(expected_edges, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_1(self):
+    def test_add_edges_1(self, edges):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
         """
-        ids = ["0", "1", "2"]
-        edges = [
-            Edge(data={"source": source, "target": target})
-            for source, target in zip(ids[:-1], ids[1:])
-        ]
-        edges_weighted = [
-            Edge(data={"source": "0", "target": "1", "weight": str(i)})
-            for i in range(1, 3)
-        ]
-        edge_inv = Edge(data={"source": "1", "target": "0"})
-
-        edges += edges_weighted
-        edges += [edge_inv]
 
         expected_nodes = [
             Node(data={"id": "0"}, position={}),
@@ -279,23 +283,10 @@ class TestGraphAddMethods:
         compare_edges(expected_edges_undirected, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_2(self):
+    def test_add_edges_2(self, edges):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
         """
-        ids = ["0", "1", "2"]
-        edges = [
-            Edge(data={"source": source, "target": target})
-            for source, target in zip(ids[:-1], ids[1:])
-        ]
-        edges_weighted = [
-            Edge(data={"source": "0", "target": "1", "weight": str(i)})
-            for i in range(1, 3)
-        ]
-        edge_inv = Edge(data={"source": "1", "target": "0"})
-
-        edges += edges_weighted
-        edges += [edge_inv]
 
         expected_nodes = [
             Node(data={"id": "0"}, position={}),
@@ -313,23 +304,10 @@ class TestGraphAddMethods:
         compare_edges(expected_edges_directed, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_3(self):
+    def test_add_edges_3(self, edges):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
         """
-        ids = ["0", "1", "2"]
-        edges = [
-            Edge(data={"source": source, "target": target})
-            for source, target in zip(ids[:-1], ids[1:])
-        ]
-        edges_weighted = [
-            Edge(data={"source": "0", "target": "1", "weight": str(i)})
-            for i in range(1, 3)
-        ]
-        edge_inv = Edge(data={"source": "1", "target": "0"})
-
-        edges += edges_weighted
-        edges += [edge_inv]
 
         expected_nodes = [
             Node(data={"id": "0"}, position={}),

--- a/ipycytoscape/tests/test_graph_methods.py
+++ b/ipycytoscape/tests/test_graph_methods.py
@@ -29,7 +29,7 @@ def compare_edges(expected_edges, actual_edges):
         assert expected.classes == actual.classes
 
 
-@pytest.fixture(name="edges", scope="module")
+@pytest.fixture(name="edges", scope="function")
 def _make_edges():
     ids = ["0", "1", "2"]
     edges = [
@@ -279,7 +279,7 @@ class TestGraphAddMethods:
         ]
 
         graph = Graph()
-        graph.add_edges([copy.copy(edge) for edge in edges])
+        graph.add_edges(edges)
         compare_edges(expected_edges_undirected, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
@@ -300,7 +300,7 @@ class TestGraphAddMethods:
         ]
 
         graph = Graph()
-        graph.add_edges([copy.copy(edge) for edge in edges], directed=True)
+        graph.add_edges(edges, directed=True)
         compare_edges(expected_edges_directed, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
@@ -329,7 +329,7 @@ class TestGraphAddMethods:
         ]
 
         graph = Graph()
-        graph.add_edges([copy.copy(edge) for edge in edges], multiple_edges=True)
+        graph.add_edges(edges, multiple_edges=True)
         compare_edges(expected_edges_multiple, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 

--- a/ipycytoscape/tests/test_graph_methods.py
+++ b/ipycytoscape/tests/test_graph_methods.py
@@ -263,7 +263,7 @@ class TestGraphAddMethods:
         compare_edges(expected_edges, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_1(self, edges):
+    def test_add_edges(self, edges):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
         """
@@ -283,9 +283,10 @@ class TestGraphAddMethods:
         compare_edges(expected_edges_undirected, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_2(self, edges):
+    def test_add_edges_directed(self, edges):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
+        for directed edges
         """
 
         expected_nodes = [
@@ -304,9 +305,10 @@ class TestGraphAddMethods:
         compare_edges(expected_edges_directed, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_3(self, edges):
+    def test_add_edges_multiple_edges(self, edges):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
+        with multiple_edges
         """
 
         expected_nodes = [
@@ -333,7 +335,7 @@ class TestGraphAddMethods:
         compare_edges(expected_edges_multiple, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges_4(self):
+    def test_add_edges_2(self):
         """
         Test to ensure that an edge with the corresponding nodes will be added to the graph
         """

--- a/ipycytoscape/tests/test_graph_methods.py
+++ b/ipycytoscape/tests/test_graph_methods.py
@@ -246,7 +246,7 @@ class TestGraphAddMethods:
         compare_edges(expected_edges, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges(self):
+    def test_add_edges_1(self):
         """
         Test to ensure that edges with the corresponding nodes will be added to the graph
         """
@@ -273,10 +273,68 @@ class TestGraphAddMethods:
             Edge(classes="", data={"source": "0", "target": "1"}),
             Edge(classes="", data={"source": "1", "target": "2"}),
         ]
+
+        graph = Graph()
+        graph.add_edges([copy.copy(edge) for edge in edges])
+        compare_edges(expected_edges_undirected, graph.edges)
+        compare_nodes(expected_nodes, graph.nodes)
+
+    def test_add_edges_2(self):
+        """
+        Test to ensure that edges with the corresponding nodes will be added to the graph
+        """
+        ids = ["0", "1", "2"]
+        edges = [
+            Edge(data={"source": source, "target": target})
+            for source, target in zip(ids[:-1], ids[1:])
+        ]
+        edges_weighted = [
+            Edge(data={"source": "0", "target": "1", "weight": str(i)})
+            for i in range(1, 3)
+        ]
+        edge_inv = Edge(data={"source": "1", "target": "0"})
+
+        edges += edges_weighted
+        edges += [edge_inv]
+
+        expected_nodes = [
+            Node(data={"id": "0"}, position={}),
+            Node(data={"id": "1"}, position={}),
+            Node(data={"id": "2"}, position={}),
+        ]
         expected_edges_directed = [
             Edge(classes=" directed ", data={"source": "0", "target": "1"}),
             Edge(classes=" directed ", data={"source": "1", "target": "2"}),
             Edge(classes=" directed ", data={"source": "1", "target": "0"}),
+        ]
+
+        graph = Graph()
+        graph.add_edges([copy.copy(edge) for edge in edges], directed=True)
+        compare_edges(expected_edges_directed, graph.edges)
+        compare_nodes(expected_nodes, graph.nodes)
+
+    def test_add_edges_3(self):
+        """
+        Test to ensure that edges with the corresponding nodes will be added to the graph
+        """
+        ids = ["0", "1", "2"]
+        edges = [
+            Edge(data={"source": source, "target": target})
+            for source, target in zip(ids[:-1], ids[1:])
+        ]
+        edges_weighted = [
+            Edge(data={"source": "0", "target": "1", "weight": str(i)})
+            for i in range(1, 3)
+        ]
+        edge_inv = Edge(data={"source": "1", "target": "0"})
+
+        edges += edges_weighted
+        edges += [edge_inv]
+
+        expected_nodes = [
+            Node(data={"id": "0"}, position={}),
+            Node(data={"id": "1"}, position={}),
+            Node(data={"id": "2"}, position={}),
         ]
         expected_edges_multiple = [
             Edge(classes=" multiple_edges ", data={"source": "0", "target": "1"}),
@@ -293,21 +351,11 @@ class TestGraphAddMethods:
         ]
 
         graph = Graph()
-        graph.add_edges([copy.copy(edge) for edge in edges])
-        compare_edges(expected_edges_undirected, graph.edges)
-        compare_nodes(expected_nodes, graph.nodes)
-
-        graph = Graph()
-        graph.add_edges([copy.copy(edge) for edge in edges], directed=True)
-        compare_edges(expected_edges_directed, graph.edges)
-        compare_nodes(expected_nodes, graph.nodes)
-
-        graph = Graph()
         graph.add_edges([copy.copy(edge) for edge in edges], multiple_edges=True)
         compare_edges(expected_edges_multiple, graph.edges)
         compare_nodes(expected_nodes, graph.nodes)
 
-    def test_add_edges(self):
+    def test_add_edges_4(self):
         """
         Test to ensure that an edge with the corresponding nodes will be added to the graph
         """


### PR DESCRIPTION
Rather than defining the edges in line in the tests this uses a pytest fixture to define them
This enables us to split the tests into individual functions without too much code duplication. That in turn fixes the test error in 
https://github.com/cytoscape/ipycytoscape/pull/300 It seems like ``copy.copy`` does not really do a deep copy (at least in the python 3.6 version used in github actions) 

Since we are using a function scoped fixture recreated for each test we can drop the use of copy.copy

Note that if we use module scoped fixtures  with copy.copy as in a0968e1df17b03e96484a1e7f41f085d55c89e79 I can reproduce the same error as in #300


