### PR TITLE
Extend watch to rebuild labextension

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:ie": "karma start --browsers=IE tests/karma.conf.js",
     "watch": "npm-run-all -p watch:*",
     "watch:lib": "tsc -w",
-    "watch:nbextension": "webpack --watch",
+    "watch:nbextension": "webpack --watch --mode=development",
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "test:ie": "karma start --browsers=IE tests/karma.conf.js",
     "watch": "npm-run-all -p watch:*",
     "watch:lib": "tsc -w",
-    "watch:nbextension": "webpack --watch"
+    "watch:nbextension": "webpack --watch",
+    "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4.0.0",


### PR DESCRIPTION
Without this I find reloading the labextension as described in the readme does not work. Adding this and it seems to work correctly. I have taken this dirrectly from the settings in ipympl https://github.com/matplotlib/ipympl/blob/master/package.json#L34 

And set webpack in development mode to avoid a warning about mode being unset when watching