### PR TITLE
add dev build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,15 @@
     "url": "https://github.com/cytoscape/ipycytoscape"
   },
   "scripts": {
-    "build": "npm run build:lib && npm run build:all",
+    "build:prod": "npm run build:lib && npm run build:all",
+    "build": "npm run build:lib && npm run build:all:dev",
     "build:labextension": "npm run clean:labextension && jupyter labextension build .",
+    "build:labextension:dev": "npm run clean:labextension && jupyter labextension build --development True .",
     "build:lib": "tsc",
     "build:nbextension": "webpack --mode=production",
+    "build:nbextension:dev": "webpack --mode=development",
     "build:all": "npm run build:labextension && npm run build:nbextension",
+    "build:all:dev": "npm run build:labextension:dev && npm run build:nbextension:dev",
     "clean": "npm run clean:lib && npm run clean:nbextension",
     "clean:lib": "rimraf lib",
     "clean:labextension": "rimraf ipycytoscape/labextension",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ cmdclass = create_cmdclass(
     "jsdeps", package_data_spec=package_data_spec, data_files_spec=data_files_spec
 )
 cmdclass["jsdeps"] = combine_commands(
-    install_npm(HERE, build_cmd="build"),
+    install_npm(HERE, build_cmd="build:prod"),
     ensure_targets(jstargets),
 )
 


### PR DESCRIPTION
And rename production build to build:prod.
That matches ipympl and widget-ts-cookiecutter

With this change one can do

pip install -e .
npm run build
jupyter labextension develop . --overwrite

to get unminified javascript that is easier to debug.
E.g. exceptions in the browser console will point directly
to a readable line of js.